### PR TITLE
Track the push performance

### DIFF
--- a/attack_load.sh
+++ b/attack_load.sh
@@ -8,6 +8,11 @@ export PARALLELISM=1
 export NUM_USERS=1
 export CONCURRENT_JOBS=10
 
+export UUID=$(uuidgen)
+export ES=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
+export ES_PORT=80
+
+
 kubectl delete ns quay-perf
 kubectl create ns quay-perf
 kubectl delete cm load-script -n quay-perf --ignore-not-found


### PR DESCRIPTION
This change enables us to track the push performance.

This will be indexed into elasticserach in the index: repo-push-timing

To create the index :
```
DELETE /repo-push-timing
PUT /repo-push-timing
POST _template/repo-push-timing
{
  "index_patterns": ["repo-push-timing"],
  "mappings":{
    "properties":{
      "timestamp": {
        "type": "date"
      },
      "start_time" :{
        "type": "date"
      },
      "end_time" :{
        "type": "date"
      }
    }
  }
}
```