### PR TITLE
Added application profiling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ DELETE /api/v1/organization/test/team/team_1/members/member_1 # delete_team_memb
 DELETE /api/v1/repository/test/repo_1/permissions/team/team_1 # delete_teams_of_organizations_repos method  
 DELETE /api/v1/repository/test/repo_1/permissions/user/user_1 # delete_users_of_organizations_repos method  
 DELETE /api/v1/repository/test/repo_1/tag/tag_1 # delete_repository_tags method  
+
+## **Profiling**
+### **Application Level Profiling**
+Inorder to perform application level profiling we use [pyroscope](https://pyroscope.io/docs/). To install pyroscope onto your cluster, deploy `assets/pyroscope-server.yaml`. Now wait until the pods are up and running in the `pyroscope` namespace. For other installation methods please refer [this](https://pyroscope.io/docs/server-install-macos/).   
+Once pyroscope is ready, we should be able to logon to the pyroscope route in the `pyroscope` namespace and view the application level profiling data using the tags applied as filters. Please refer to this [tutorial](https://github.com/grafana/pyroscope/tree/main/examples/python/rideshare) and live [demo](https://demo.pyroscope.io/explore?query=rideshare-app-python.cpu%7B%7D&groupBy=region&groupByValue=All) for more details on integration.

--- a/assets/pyroscope-server.yaml
+++ b/assets/pyroscope-server.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pyroscope
+  namespace: pyroscope
+  labels:
+    app: pyroscope
+spec:
+  containers:
+    - name: pyroscope
+      image: pyroscope/pyroscope
+      env:
+        - name: PYROSCOPE_LOG_LEVEL
+          value: debug
+      ports:
+        - containerPort: 4040
+      command:
+        - /usr/bin/pyroscope
+        - server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope
+  namespace: pyroscope
+spec:
+  selector:
+    app: pyroscope
+  ports:
+    - protocol: TCP
+      port: 4040
+      targetPort: 4040
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pyroscope
+  namespace: pyroscope
+spec:
+  to:
+    kind: Service
+    name: pyroscope
+  port:
+    targetPort: 4040
+  wildcardPolicy: None


### PR DESCRIPTION
### Description
Added instructions and tutorial information to integrate application profiling. We need to add tags in the quay application source code in order to properly fetch the trace in flame graphs.

### Testing
Integrating tags in this load generator code will not provide much information in the [flame-graphs](http://pyroscope-pyroscope.apps.vchalla-clair-test-8.perfscale.devcluster.openshift.com/?query=quay.performance-scripts.app.cpu%7B%7D&rightQuery=quay.performance-scripts.app.cpu%7B%7D&leftQuery=quay.performance-scripts.app.cpu%7B%7D&from=now-30d) as shown below.
![python_profiling_poc](https://github.com/quay/quay-performance-scripts/assets/28471457/7fa621d8-7c8b-4de4-bde8-75ef64af1b4f)
So the suggestion is to add tags in the quay source code and use the scripts in this repo to generate load and monitor the CPU IO time.