### PR TITLE
Adding push/pull phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@ WORKDIR /tmp
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install necessary libraries for subsequent commands
-RUN apt-get update && apt-get install -y podman wget git dumb-init python3.6 python3-distutils python3-pip python3-apt redis-server
+RUN apt-get update && \
+    apt-get install -y software-properties-common python3.6 python3-venv python3-pip python3-apt wget git dumb-init podman redis-server
+
+# Create and activate virtual environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 # Install vegeta for HTTP benchmarking
 RUN wget https://github.com/tsenart/vegeta/releases/download/v12.8.3/vegeta-12.8.3-linux-amd64.tar.gz \
  && tar -xzf vegeta-12.8.3-linux-amd64.tar.gz \
@@ -17,8 +23,9 @@ RUN wget https://github.com/tsenart/vegeta/releases/download/v12.8.3/vegeta-12.8
 RUN mkdir -p /opt/snafu/ \
  && wget -O /tmp/benchmark-wrapper.tar.gz https://github.com/cloud-bulldozer/benchmark-wrapper/archive/refs/tags/v1.0.0.tar.gz \
  && tar -xzf /tmp/benchmark-wrapper.tar.gz -C /opt/snafu/ --strip-components=1 \
- && pip3 install --upgrade pip \
- && pip3 install -e /opt/snafu/ \
+ && pip install --upgrade pip \
+ && pip install -e /opt/snafu/ \
+ && pip install "numpy<2" \
  && rm -rf /tmp/benchmark-wrapper.tar.gz
 
 COPY . .

--- a/config.py
+++ b/config.py
@@ -59,4 +59,4 @@ class Config:
         assert isinstance(self.config["batch_size"], int), "BATCH_SIZE is not an integer"
         assert self.config["test_namespace"], "TEST_NAMESPACE is not set"
         assert self.config["base_url"], "BASE_URL is not set"
-        assert self.config["test_phases"], "TEST_PHASES are not set. Valid options are LOAD,RUN and DELETE"
+        assert self.config["test_phases"], "TEST_PHASES are not set. Valid options are LOAD,RUN, PUSH_PULL and DELETE"


### PR DESCRIPTION
### Description
Adding push/pull phase to only test push pull which a given user login details. This will be helpful to test both quay.io and quay-operator as well


### Testing
Tested and verified by testing it on quay.io staging environment details shared by @SeanZhao-redhat 

#### Input ENVs in the config
```
        env:
          - name: QUAY_HOST
            value: "stage_url"
          - name: QUAY_OAUTH_TOKEN
            value: "TOKEN"
          - name: QUAY_ORG
            value: "testorg"
          - name: ES_HOST
            value: "ES_URL"
          - name: ES_PORT
            value: "443"
          - name: PYTHONUNBUFFERED
            value: "0"
          - name: ES_INDEX
            value: "quay-vegeta"
          - name: PUSH_PULL_IMAGE
            value: "IMAGE_URL"
          - name: PUSH_PULL_ES_INDEX
            value: "quay-push-pull"
          - name: PUSH_PULL_NUMBERS
            value:  "5"
          - name: TARGET_HIT_SIZE
            value: "10"
          - name: CONCURRENCY
            value: "15"
          - name: TEST_NAMESPACE
            value: "quay-ptt"
          - name: "TEST_PHASES"
            value: "push_pull"
          - name: QUAY_USERNAME
            value: "USERNAME" 
          - name: QUAY_PASSWORD
            value: "PASSWORD"  
```
#### Output logs
```
vchalla@vchalla-thinkpadp1gen2:~/quay-performance-scripts$ oc logs pod/quay-perf-test-orchestrator-hfqdl
/tmp/main.py:662: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  date=datetime.datetime.utcnow().isoformat(),
INFO:root:Running Quay Scale & Performance Tests	date=2024-09-23T19:57:09.966400 host=https://stage.quay.io test_uuid=260b587a-c528-4435-ac31-74db597e612c organization=seanorg num_users=10 num_repos=11 num_teams=10 target_hit_size=10 concurrency=15 repos_with_tags_sizes=(5,) total_tags=5 pull_push_batch_size=400
/tmp/main.py:698: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  start_time = datetime.datetime.utcnow()
INFO:root:Starting image push/pulls (UTC): 2024-09-23 19:58:09.966724
INFO:root:Queued 5 tags to be created
INFO:root:Queued 5 tags to be pulled
INFO:root:Created Job: test-registry-pushquay-qe
INFO:root:Job test-registry-pushquay-qe has been completed.
INFO:root:Created Job: test-registry-pullquay-qe
INFO:root:Job test-registry-pullquay-qe has been completed.
/tmp/main.py:701: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  end_time = datetime.datetime.utcnow()
INFO:root:Ending image push/pulls (UTC): 2024-09-23 20:00:10.049355
```