### PR TITLE
Add 401 token refresh logic for image pulls

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,51 +264,85 @@ def get_auth_token(registry, repository, username=None, password=None):
         return None
 
 
-def get_image_manifest(registry, repository, tag, token):
+def get_image_manifest(registry, repository, tag, token, username=None, password=None, max_token_refresh=3):
     """
     Fetch the manifest for a given image tag.
-    Returns manifest JSON and list of layer digests.
+    On 401 (expired token), refreshes the auth token and retries.
+    Returns (layer_digests, current_token) tuple.
     """
     manifest_url = f"https://{registry}/v2/{repository}/manifests/{tag}"
-    headers = {
-        'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
-    }
-    
-    if token:
-        headers['Authorization'] = f'Bearer {token}'
-    
-    try:
-        response = requests.get(manifest_url, headers=headers, verify=False)
-        logging.debug(f"Fetching manifest for {tag}, HTTP {response.status_code}")
-        response.raise_for_status()
-        manifest = response.json()
-        
-        # Extract layer digests
-        layers = []
-        if 'layers' in manifest:
-            layers = [layer['digest'] for layer in manifest['layers']]
-        elif 'fsLayers' in manifest:  # Older manifest format
-            layers = [layer['blobSum'] for layer in manifest['fsLayers']]
-        
-        return layers
-    except Exception as e:
-        logging.error(f"Failed to get manifest for {tag}: {e}")
-        return []
+    current_token = token
+    token_refresh_count = 0
+
+    while token_refresh_count <= max_token_refresh:
+        headers = {
+            'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
+        }
+
+        if current_token:
+            headers['Authorization'] = f'Bearer {current_token}'
+
+        try:
+            response = requests.get(manifest_url, headers=headers, verify=False)
+            logging.debug(f"Fetching manifest for {tag}, HTTP {response.status_code}")
+
+            if response.status_code == 401 and token_refresh_count < max_token_refresh:
+                token_refresh_count += 1
+                new_token = get_auth_token(registry, repository, username, password)
+                if new_token:
+                    current_token = new_token
+                    logging.info(f"Manifest {tag} got 401, token refreshed successfully (refresh {token_refresh_count}/{max_token_refresh})")
+                else:
+                    logging.warning(f"Manifest {tag} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
+                continue
+
+            response.raise_for_status()
+            manifest = response.json()
+
+            layers = []
+            if 'layers' in manifest:
+                layers = [layer['digest'] for layer in manifest['layers']]
+            elif 'fsLayers' in manifest:  # Older manifest format
+                layers = [layer['blobSum'] for layer in manifest['fsLayers']]
+
+            return layers, current_token
+        except Exception as e:
+            logging.error(f"Failed to get manifest for {tag}: {e}")
+            return [], current_token
+
+    return [], current_token
 
 
-def fetch_layer_with_retries(registry, repository, digest, token, max_attempts=3):
+def fetch_layer_with_retries(registry, repository, digest, token, username=None, password=None, max_attempts=3, max_token_refresh=3):
     """
     Attempt to download a single layer up to max_attempts times.
+    On 401 (expired token), refreshes the auth token and retries
+    without consuming a retry attempt.
     Returns True on success, False on permanent failure.
     """
     url = f"https://{registry}/v2/{repository}/blobs/{digest}"
-    headers = {"Authorization": f"Bearer {token}"}
+    current_token = token
+    token_refresh_count = 0
     attempt = 0
+
     while attempt < max_attempts:
         attempt += 1
         try:
+            headers = {"Authorization": f"Bearer {current_token}"}
             with requests.get(url, headers=headers, stream=True, verify=False) as r:
                 logging.debug(f"Fetching layer {digest}, attempt {attempt}, HTTP {r.status_code}")
+
+                if r.status_code == 401 and token_refresh_count < max_token_refresh:
+                    token_refresh_count += 1
+                    new_token = get_auth_token(registry, repository, username, password)
+                    if new_token:
+                        current_token = new_token
+                        logging.info(f"Layer {digest} got 401, token refreshed successfully (refresh {token_refresh_count}/{max_token_refresh})")
+                    else:
+                        logging.warning(f"Layer {digest} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
+                    attempt -= 1
+                    continue
+
                 r.raise_for_status()
                 sha = hashlib.sha256()
                 for chunk in r.iter_content(chunk_size=2 * 1024 * 1024):  # 2MB chunks
@@ -358,7 +392,7 @@ def pull_single_image_http(tag, username=None, password=None, max_failures=3):
             'successful': False,
         }
 
-    digests = get_image_manifest(registry, repository, image_tag, token)
+    digests, token = get_image_manifest(registry, repository, image_tag, token, username, password)
     if not digests:
         end_time = datetime.datetime.utcnow()
         elapsed_time = (end_time - start_time).total_seconds()
@@ -379,7 +413,7 @@ def pull_single_image_http(tag, username=None, password=None, max_failures=3):
     # Submit layer fetch tasks (each task includes its own retry logic)
     with ThreadPoolExecutor(max_workers=6) as layer_pool:
         futures = {
-            layer_pool.submit(fetch_layer_with_retries, registry, repository, d, token, max_failures): d
+            layer_pool.submit(fetch_layer_with_retries, registry, repository, d, token, username, password, max_failures): d
             for d in digests
         }
         for fut in as_completed(futures):

--- a/main.py
+++ b/main.py
@@ -264,7 +264,7 @@ def get_auth_token(registry, repository, username=None, password=None):
         return None
 
 
-def refresh_token_on_401(registry, repository, username, password, token_refresh_count, max_token_refresh, context_label):
+def refresh_token_on_401(registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, context_label):
     token_refresh_count += 1
     new_token = get_auth_token(registry, repository, username, password)
     if new_token:
@@ -272,7 +272,7 @@ def refresh_token_on_401(registry, repository, username, password, token_refresh
         return new_token, token_refresh_count
     else:
         logging.warning(f"{context_label} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
-        return None, token_refresh_count
+        return current_token, token_refresh_count
 
 
 def get_image_manifest(registry, repository, tag, token, username=None, password=None, max_token_refresh=3):
@@ -298,10 +298,8 @@ def get_image_manifest(registry, repository, tag, token, username=None, password
             logging.debug(f"Fetching manifest for {tag}, HTTP {response.status_code}")
 
             if response.status_code == 401 and token_refresh_count < max_token_refresh:
-                new_token, token_refresh_count = refresh_token_on_401(
-                    registry, repository, username, password, token_refresh_count, max_token_refresh, f"Manifest {tag}")
-                if new_token:
-                    current_token = new_token
+                current_token, token_refresh_count = refresh_token_on_401(
+                    registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, f"Manifest {tag}")
                 continue
 
             response.raise_for_status()
@@ -341,10 +339,8 @@ def fetch_layer_with_retries(registry, repository, digest, token, username=None,
                 logging.debug(f"Fetching layer {digest}, attempt {attempt}, HTTP {r.status_code}")
 
                 if r.status_code == 401 and token_refresh_count < max_token_refresh:
-                    new_token, token_refresh_count = refresh_token_on_401(
-                        registry, repository, username, password, token_refresh_count, max_token_refresh, f"Layer {digest}")
-                    if new_token:
-                        current_token = new_token
+                    current_token, token_refresh_count = refresh_token_on_401(
+                        registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, f"Layer {digest}")
                     attempt -= 1
                     continue
 

--- a/main.py
+++ b/main.py
@@ -264,15 +264,17 @@ def get_auth_token(registry, repository, username=None, password=None):
         return None
 
 
-def refresh_token_on_401(registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, context_label):
+def handle_token_refresh(status_code, registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, context_label):
+    if status_code != 401 or token_refresh_count >= max_token_refresh:
+        return False, current_token, token_refresh_count
     token_refresh_count += 1
     new_token = get_auth_token(registry, repository, username, password)
     if new_token:
         logging.info(f"{context_label} got 401, token refreshed successfully (refresh {token_refresh_count}/{max_token_refresh})")
-        return new_token, token_refresh_count
+        return True, new_token, token_refresh_count
     else:
         logging.warning(f"{context_label} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
-        return current_token, token_refresh_count
+        return True, current_token, token_refresh_count
 
 
 def get_image_manifest(registry, repository, tag, token, username=None, password=None, max_token_refresh=3):
@@ -297,9 +299,9 @@ def get_image_manifest(registry, repository, tag, token, username=None, password
             response = requests.get(manifest_url, headers=headers, verify=False)
             logging.debug(f"Fetching manifest for {tag}, HTTP {response.status_code}")
 
-            if response.status_code == 401 and token_refresh_count < max_token_refresh:
-                current_token, token_refresh_count = refresh_token_on_401(
-                    registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, f"Manifest {tag}")
+            refreshed, current_token, token_refresh_count = handle_token_refresh(
+                response.status_code, registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, f"Manifest {tag}")
+            if refreshed:
                 continue
 
             response.raise_for_status()
@@ -338,9 +340,9 @@ def fetch_layer_with_retries(registry, repository, digest, token, username=None,
             with requests.get(url, headers=headers, stream=True, verify=False) as r:
                 logging.debug(f"Fetching layer {digest}, attempt {attempt}, HTTP {r.status_code}")
 
-                if r.status_code == 401 and token_refresh_count < max_token_refresh:
-                    current_token, token_refresh_count = refresh_token_on_401(
-                        registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, f"Layer {digest}")
+                refreshed, current_token, token_refresh_count = handle_token_refresh(
+                    r.status_code, registry, repository, username, password, current_token, token_refresh_count, max_token_refresh, f"Layer {digest}")
+                if refreshed:
                     attempt -= 1
                     continue
 

--- a/main.py
+++ b/main.py
@@ -264,6 +264,17 @@ def get_auth_token(registry, repository, username=None, password=None):
         return None
 
 
+def refresh_token_on_401(registry, repository, username, password, token_refresh_count, max_token_refresh, context_label):
+    token_refresh_count += 1
+    new_token = get_auth_token(registry, repository, username, password)
+    if new_token:
+        logging.info(f"{context_label} got 401, token refreshed successfully (refresh {token_refresh_count}/{max_token_refresh})")
+        return new_token, token_refresh_count
+    else:
+        logging.warning(f"{context_label} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
+        return None, token_refresh_count
+
+
 def get_image_manifest(registry, repository, tag, token, username=None, password=None, max_token_refresh=3):
     """
     Fetch the manifest for a given image tag.
@@ -287,13 +298,10 @@ def get_image_manifest(registry, repository, tag, token, username=None, password
             logging.debug(f"Fetching manifest for {tag}, HTTP {response.status_code}")
 
             if response.status_code == 401 and token_refresh_count < max_token_refresh:
-                token_refresh_count += 1
-                new_token = get_auth_token(registry, repository, username, password)
+                new_token, token_refresh_count = refresh_token_on_401(
+                    registry, repository, username, password, token_refresh_count, max_token_refresh, f"Manifest {tag}")
                 if new_token:
                     current_token = new_token
-                    logging.info(f"Manifest {tag} got 401, token refreshed successfully (refresh {token_refresh_count}/{max_token_refresh})")
-                else:
-                    logging.warning(f"Manifest {tag} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
                 continue
 
             response.raise_for_status()
@@ -333,13 +341,10 @@ def fetch_layer_with_retries(registry, repository, digest, token, username=None,
                 logging.debug(f"Fetching layer {digest}, attempt {attempt}, HTTP {r.status_code}")
 
                 if r.status_code == 401 and token_refresh_count < max_token_refresh:
-                    token_refresh_count += 1
-                    new_token = get_auth_token(registry, repository, username, password)
+                    new_token, token_refresh_count = refresh_token_on_401(
+                        registry, repository, username, password, token_refresh_count, max_token_refresh, f"Layer {digest}")
                     if new_token:
                         current_token = new_token
-                        logging.info(f"Layer {digest} got 401, token refreshed successfully (refresh {token_refresh_count}/{max_token_refresh})")
-                    else:
-                        logging.warning(f"Layer {digest} got 401, token refresh failed, retrying with existing token (refresh {token_refresh_count}/{max_token_refresh})")
                     attempt -= 1
                     continue
 


### PR DESCRIPTION
**Description:**
  Auth tokens can expire during long pull tests. Previously, 401s caused permanent failures since retries reused the same expired token.

**Changes:**
  - get_image_manifest and fetch_layer_with_retries now detect 401 and request a fresh token before retrying
  - Token refreshes use a separate counter from retry attempts so they don't consume retry attempts

**Testing**
- Tested locally